### PR TITLE
fix periodicity calculation

### DIFF
--- a/.github/workflows/check-build.yml
+++ b/.github/workflows/check-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Dependencies
         run: |
@@ -41,7 +41,7 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: MSBuild
         uses: microsoft/setup-msbuild@30375c66a4eea26614e0d39710365f22f8b0af57 # v3

--- a/src/main/ap.cc
+++ b/src/main/ap.cc
@@ -44,7 +44,6 @@ const int kDefaultFftLength(256);
 const int kDefaultFrameShift(80);
 const double kDefaultSamplingRate(16.0);
 const double kDefaultLowerBound(1e-3);
-const double kDefaultUpperBound(1.0 - kDefaultLowerBound);
 const InputFormats kDefaultInputFormat(kPitch);
 const OutputFormats kDefaultOutputFormat(kAperiodicity);
 const double kDefaultF0(150.0);
@@ -65,7 +64,7 @@ void PrintUsage(std::ostream* stream) {
   *stream << "       -p p  : frame shift [point]     (   int)[" << std::setw(5) << std::right << kDefaultFrameShift   << "][   1 <= p <=      ]" << std::endl;  // NOLINT
   *stream << "       -s s  : sampling rate [kHz]     (double)[" << std::setw(5) << std::right << kDefaultSamplingRate << "][ 8.0 <= s <= 98.0 ]" << std::endl;  // NOLINT
   *stream << "       -L L  : lower bound of Ha       (double)[" << std::setw(5) << std::right << kDefaultLowerBound   << "][ 0.0 <= L <  H    ]" << std::endl;  // NOLINT
-  *stream << "       -H H  : upper bound of Ha       (double)[" << std::setw(5) << std::right << kDefaultUpperBound   << "][   L <  H <= 1.0  ]" << std::endl;  // NOLINT
+  *stream << "       -H H  : upper bound of Ha       (double)[" << std::setw(5) << std::right << "N/A"                << "][   L <  H <= 1.0  ]" << std::endl;  // NOLINT
   *stream << "       -q q  : f0 input format         (   int)[" << std::setw(5) << std::right << kDefaultInputFormat  << "][   0 <= q <= 2    ]" << std::endl;  // NOLINT
   *stream << "                 0 (Fs/F0)" << std::endl;
   *stream << "                 1 (F0)" << std::endl;
@@ -84,6 +83,7 @@ void PrintUsage(std::ostream* stream) {
   *stream << "       aperiodicity                    (double)" << std::endl;
   *stream << "  notice:" << std::endl;
   *stream << "       magic number representing unvoiced symbol is 0 (q = 0, 1) or -1e+10 (q = 2)" << std::endl;  // NOLINT
+  *stream << "       if -H is not specified, upper bound is computed automatically from lower bound" << std::endl;  // NOLINT
   *stream << std::endl;
   *stream << " SPTK: version " << sptk::kVersion << std::endl;
   *stream << std::endl;
@@ -144,7 +144,8 @@ int main(int argc, char* argv[]) {
   int frame_shift(kDefaultFrameShift);
   double sampling_rate(kDefaultSamplingRate);
   double lower_bound(kDefaultLowerBound);
-  double upper_bound(kDefaultUpperBound);
+  double upper_bound(1.0);
+  bool is_upper_bound_specified(false);
   InputFormats input_format(kDefaultInputFormat);
   OutputFormats output_format(kDefaultOutputFormat);
 
@@ -227,6 +228,7 @@ int main(int argc, char* argv[]) {
           sptk::PrintErrorMessage("ap", error_message);
           return 1;
         }
+        is_upper_bound_specified = true;
         break;
       }
       case 'q': {
@@ -270,11 +272,15 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  if (upper_bound <= lower_bound) {
-    std::ostringstream error_message;
-    error_message << "Lower bound must be less than upper one";
-    sptk::PrintErrorMessage("ap", error_message);
-    return 1;
+  if (is_upper_bound_specified) {
+    if (upper_bound <= lower_bound) {
+      std::ostringstream error_message;
+      error_message << "Lower bound must be less than upper one";
+      sptk::PrintErrorMessage("ap", error_message);
+      return 1;
+    }
+  } else {
+    upper_bound = std::sqrt(1.0 - lower_bound * lower_bound);
   }
 
   const char* f0_file;

--- a/src/main/ap.cc
+++ b/src/main/ap.cc
@@ -271,15 +271,15 @@ int main(int argc, char* argv[]) {
     }
   }
 
-  if (is_upper_bound_specified) {
-    if (upper_bound <= lower_bound) {
-      std::ostringstream error_message;
-      error_message << "Lower bound must be less than upper one";
-      sptk::PrintErrorMessage("ap", error_message);
-      return 1;
-    }
-  } else {
+  if (!is_upper_bound_specified) {
     upper_bound = std::sqrt(1.0 - lower_bound * lower_bound);
+  }
+
+  if (upper_bound <= lower_bound) {
+    std::ostringstream error_message;
+    error_message << "Lower bound must be less than upper one";
+    sptk::PrintErrorMessage("ap", error_message);
+    return 1;
   }
 
   const char* f0_file;
@@ -326,7 +326,7 @@ int main(int argc, char* argv[]) {
     switch (input_format) {
       case kPitch: {
         std::transform(f0.begin(), f0.end(), f0.begin(),
-                       [sampling_rate_in_hz, default_f0](double x) {
+                       [sampling_rate_in_hz](double x) {
                          return (0.0 == x) ? 0.0 : sampling_rate_in_hz / x;
                        });
         break;
@@ -336,10 +336,9 @@ int main(int argc, char* argv[]) {
         break;
       }
       case kLogF0: {
-        std::transform(f0.begin(), f0.end(), f0.begin(),
-                       [default_f0](double x) {
-                         return (sptk::kLogZero == x) ? 0.0 : std::exp(x);
-                       });
+        std::transform(f0.begin(), f0.end(), f0.begin(), [](double x) {
+          return (sptk::kLogZero == x) ? 0.0 : std::exp(x);
+        });
         break;
       }
       default: {

--- a/src/main/ap.cc
+++ b/src/main/ap.cc
@@ -46,7 +46,6 @@ const double kDefaultSamplingRate(16.0);
 const double kDefaultLowerBound(1e-3);
 const InputFormats kDefaultInputFormat(kPitch);
 const OutputFormats kDefaultOutputFormat(kAperiodicity);
-const double kDefaultF0(150.0);
 
 void PrintUsage(std::ostream* stream) {
   // clang-format off
@@ -326,21 +325,21 @@ int main(int argc, char* argv[]) {
 
     switch (input_format) {
       case kPitch: {
-        std::transform(
-            f0.begin(), f0.end(), f0.begin(), [sampling_rate_in_hz](double x) {
-              return (0.0 == x) ? kDefaultF0 : sampling_rate_in_hz / x;
-            });
+        std::transform(f0.begin(), f0.end(), f0.begin(),
+                       [sampling_rate_in_hz, default_f0](double x) {
+                         return (0.0 == x) ? 0.0 : sampling_rate_in_hz / x;
+                       });
         break;
       }
       case kF0: {
-        std::transform(f0.begin(), f0.end(), f0.begin(),
-                       [](double x) { return (0.0 == x) ? kDefaultF0 : x; });
+        // nothing to do
         break;
       }
       case kLogF0: {
-        std::transform(f0.begin(), f0.end(), f0.begin(), [](double x) {
-          return (sptk::kLogZero == x) ? kDefaultF0 : std::exp(x);
-        });
+        std::transform(f0.begin(), f0.end(), f0.begin(),
+                       [default_f0](double x) {
+                         return (sptk::kLogZero == x) ? 0.0 : std::exp(x);
+                       });
         break;
       }
       default: {

--- a/src/main/ap.cc
+++ b/src/main/ap.cc
@@ -15,7 +15,7 @@
 // ------------------------------------------------------------------------ //
 
 #include <algorithm>  // std::max, std::min, std::transform
-#include <cmath>      // std::exp
+#include <cmath>      // std::exp, std::sqrt
 #include <fstream>    // std::ifstream
 #include <iomanip>    // std::setw
 #include <iostream>   // std::cerr, std::cin, std::cout, std::endl, etc.
@@ -398,17 +398,17 @@ int main(int argc, char* argv[]) {
       }
       case kPeriodicity: {
         std::transform(output.begin(), output.end(), output.begin(),
-                       [](double a) { return 1.0 - a; });
+                       [](double a) { return std::sqrt(1.0 - a * a); });
         break;
       }
       case kAperiodicityOverPeriodicity: {
         std::transform(output.begin(), output.end(), output.begin(),
-                       [](double a) { return a / (1.0 - a); });
+                       [](double a) { return a / std::sqrt(1.0 - a * a); });
         break;
       }
       case kPeriodicityOverAperiodicity: {
         std::transform(output.begin(), output.end(), output.begin(),
-                       [](double a) { return (1.0 - a) / a; });
+                       [](double a) { return std::sqrt(1.0 - a * a) / a; });
         break;
       }
       default: {

--- a/src/main/world_synth.cc
+++ b/src/main/world_synth.cc
@@ -15,7 +15,7 @@
 // ------------------------------------------------------------------------ //
 
 #include <algorithm>  // std::transform
-#include <cmath>      // std::exp
+#include <cmath>      // std::exp, std::sqrt
 #include <fstream>    // std::ifstream
 #include <iomanip>    // std::setw
 #include <iostream>   // std::cerr, std::cin, std::cout, std::endl, etc.
@@ -372,17 +372,19 @@ int main(int argc, char* argv[]) {
         }
         case kPeriodicity: {
           std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                         [](double p) { return 1.0 - p; });
+                         [](double p) { return std::sqrt(1.0 - p * p); });
           break;
         }
         case kAperiodicityOverPeriodicity: {
-          std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                         [](double ap) { return ap / (1.0 + ap); });
+          std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](double ap) {
+            return ap / std::sqrt(1.0 + ap * ap);
+          });
           break;
         }
         case kPeriodicityOverAperiodicity: {
-          std::transform(tmp.begin(), tmp.end(), tmp.begin(),
-                         [](double pa) { return 1.0 / (1.0 + pa); });
+          std::transform(tmp.begin(), tmp.end(), tmp.begin(), [](double pa) {
+            return 1.0 / std::sqrt(1.0 + pa * pa);
+          });
           break;
         }
         default: {

--- a/third_party/WORLD/aperiodicity.cc
+++ b/third_party/WORLD/aperiodicity.cc
@@ -582,28 +582,46 @@ void CalculateAperiodicity(double *coarse_aperiodicity, int number_of_bands,
     return;
   }
   // 0 Hz and fs / 2 Hz are added for interporation
+#if 0
   double *coarse_aperiodicity_expand = new double[number_of_bands + 1];
   double *coarse_axis = new double[number_of_bands + 1];
+#else
+  double *coarse_aperiodicity_expand = new double[number_of_bands + 2];
+  double *coarse_axis = new double[number_of_bands + 2];
+#endif
   double *frequency_axis = new double[fft_size / 2 + 1];
 
 #if 0
   const double kMySafeGuardLogMinimum = -21.416413017506358;
-#else
-  const double kMySafeGuardLogMinimum = log(coarse_aperiodicity[0]);
-#endif
 
   coarse_aperiodicity_expand[0] = kMySafeGuardLogMinimum;
+#else
+  coarse_aperiodicity_expand[0] = log(coarse_aperiodicity[0]);
+#endif
   coarse_axis[0] = 0.0;
   for (int i = 0; i < number_of_bands; ++i) {
     coarse_aperiodicity_expand[i + 1] = log(coarse_aperiodicity[i]);
     coarse_axis[i + 1] = fs / pow(2.0, number_of_bands - i) *
+#if 0
       stretching_factor;
+#else
+      sqrt(0.5) * stretching_factor;
+#endif
   }
+#if 1
+  coarse_aperiodicity_expand[number_of_bands + 1] =
+    coarse_aperiodicity_expand[number_of_bands];
+  coarse_axis[number_of_bands + 1] = fs;
+#endif
 
   for (int i = 0; i <= fft_size / 2; ++i)
     frequency_axis[i] = static_cast<double>(i * fs) / fft_size;
 
+#if 0
   interp1(coarse_axis, coarse_aperiodicity_expand, number_of_bands + 1,
+#else
+  interp1(coarse_axis, coarse_aperiodicity_expand, number_of_bands + 2,
+#endif
       frequency_axis, fft_size / 2 + 1, aperiodicity);
 
   for (int i = 0; i <= fft_size / 2; ++i)


### PR DESCRIPTION
This PR fixes the three issues shown below in aperiodicity extraction and introduces breaking changes.
                                                                       
  - **Unvoiced frames were analyzed as 150 Hz voiced frames.** `ap` replaced the
    unvoiced symbol with a default F0 of 150 Hz before calling the extractors.
    Both TANDEM-STRAIGHT and WORLD (D4C) handle `f0 == 0` as unvoiced internally,
    so the F0 is now passed through as zero and their own unvoiced handling is
    used. If overwriting the F0 values in unvoiced region is still desired, it can be done
    explicitly with `sopr` instead.
                                                                       
  - **Periodicity was defined as `1 - Ha` instead of `sqrt(1 - Ha^2)`.** WORLD
    splits the power spectrum into periodic and aperiodic parts as `1 - Ha^2` and
    `Ha^2`, i.e. the amplitude ratios satisfy `Ha^2 + Hp^2 = 1`. The output
    formats of `ap` (`-o 1/2/3`) and the corresponding inverse conversions in
    `world_synth` (`-A 1/2/3`) are updated accordingly. The default upper bound
    of `Ha` follows the same relation and is now derived from the lower bound as
    `sqrt(1 - L^2)`.              
                                                                       
  - **The TANDEM band aperiodicity was placed on the wrong frequency axis.** Each
    octave band value was assigned to the upper edge of the band, which shifted
    the whole interpolated spectrum. It is now assigned to the geometric center
    of the band, with the value of the highest band held flat up to the Nyquist frequency.  
                                                                       